### PR TITLE
Dashboard minor styling

### DIFF
--- a/app/views/components/_dashboard.html.erb
+++ b/app/views/components/_dashboard.html.erb
@@ -1,17 +1,17 @@
 <div class="dashboard">
   <div class="dashboard-grocery">
-    <h3>You are missing only:</h3>
+    <h3>Your missing ingredients:</h3>
     <ul class="grocery-list">
       <% grocery_list.each do |item| %>
-        <li class="grocery-list-item"><%= item.name.capitalize %></li>
+        <li class="grocery-list-item"><%= item.name.titleize %></li>
       <% end %>
     </ul>
   </div>
   <div class="dashboard-saved-cocktails">
-    <h3>Your selected cocktail</h3>
+    <h3>Your selected cocktails:</h3>
     <ul class="saved-cocktails-list">
       <% saved_cocktails.each do |saved_cocktail| %>
-        <li class="saved-cocktails-list-item"><%= saved_cocktail.cocktail.name.capitalize %></li>
+        <li class="saved-cocktails-list-item"><%= saved_cocktail.cocktail.name.titleize %></li>
       <% end %>
     </ul>
   </div>


### PR DESCRIPTION
Headers changed and items for both lists are now 'titleized':

<img width="1437" alt="Screenshot 2022-09-05 at 3 17 15 PM" src="https://user-images.githubusercontent.com/103326869/188459347-d29c27c7-db24-4260-92b9-5eefd709cf8e.png">
