### PR TITLE
Fixing bugs

### DIFF
--- a/app/assets/stylesheets/components/_index_card.scss
+++ b/app/assets/stylesheets/components/_index_card.scss
@@ -27,11 +27,6 @@
   align-items: center;
   justify-content: center;
   border-bottom: 2px solid black;
-  & :hover{
-    cursor: pointer;
-    color: $orange-hb;
-    opacity: 0.9;
-  }
 }
 
 .index-card-stock {
@@ -59,6 +54,11 @@
   justify-content: center;
   flex-grow: 2;
   height: 4rem;
+   & :hover{
+    cursor: pointer;
+    color: $orange-hb;
+    opacity: 0.9;
+  }
 }
 
 .index-card-bottom {
@@ -119,4 +119,3 @@ button {
 .fa-circle-minus:hover {
   color: $black-hb;
 }
-

--- a/app/views/components/_saved_cocktail_card.html.erb
+++ b/app/views/components/_saved_cocktail_card.html.erb
@@ -16,6 +16,9 @@
           <% when num == 2 %>
             <%#= '-2' %>
             2 <i class="fa-solid fa-basket-shopping fa-xs"></i>
+          <% else %>
+            <%#= 'more than two ingredients missing' %>
+            <i class="fa-solid fa-cart-shopping fa-lg"></i>
           <% end %>
         </p>
       </div>


### PR DESCRIPTION
1. No problem now hovering icons of ready to go, 2 ingredients missing, etc... when cocktails are selected
![image](https://user-images.githubusercontent.com/99300646/189075352-f23d0183-9807-466e-93d9-be5406c88b9f.png)


2. Cart-shopping icon when more than two ingredients are missing in the selected cocktails of My Bar page
![image](https://user-images.githubusercontent.com/99300646/189075681-d712cf84-6e38-4830-9c40-d647bac6b083.png)
