### PR TITLE
My bar (saved/selected cocktails) number fixed according to current user

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,8 +15,8 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto">
         <% if user_signed_in? %>
-          <% if SavedCocktail.count > 0 %>
-            <p class="selected-cocktails-number"><%= SavedCocktail.count %></p>
+          <% if SavedCocktail.where(user: current_user).count > 0 %>
+            <p class="selected-cocktails-number"><%= SavedCocktail.where(user: current_user).count %></p>
           <% end %>
           <li class="nav-item active">
             <% if current_page?(cocktails_path) %>


### PR DESCRIPTION
Fixing one small bug generated by myself : the number of saved/selected cocktails of My Bar in the navbar now shows the number of saved/selected cocktails of the current user only.
![localhost_3000_](https://user-images.githubusercontent.com/99300646/193609572-c478a497-3e8b-4083-b17c-2e9b2c8b8d87.png)
