### PR TITLE
Responsive design

### DIFF
--- a/app/assets/stylesheets/components/_cabinet.scss
+++ b/app/assets/stylesheets/components/_cabinet.scss
@@ -12,6 +12,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 2rem;
 }
 
 .search-bar {
@@ -48,8 +49,25 @@
   color:inherit;
 }
 
-.fa-xmark {
-  padding-left: 1rem;
+// Small devices (up to 767px)
+@media (max-width: 767px) {
+  .search-info {
+    display: inline;
+    text-align: center;
+    padding-bottom: 0;
+  }
+
+  .search-bar {
+    width: 100%;
+  }
+
+  .cabinet-ingredients {
+  padding: 0rem 1rem 1rem 1rem;
+  }
+}
+
+.fa-square-minus {
+  color: $black-hb;
 }
 
 .remover {

--- a/app/assets/stylesheets/components/_dashboard.scss
+++ b/app/assets/stylesheets/components/_dashboard.scss
@@ -74,3 +74,11 @@
 }
 
 // fa-solid fa-share-nodes
+
+
+// Small devices (up to 767px)
+@media (max-width: 767px) {
+  .dashboard {
+    gap: 1rem;
+  }
+}

--- a/app/assets/stylesheets/components/_index_card.scss
+++ b/app/assets/stylesheets/components/_index_card.scss
@@ -1,7 +1,5 @@
 .index-card-wrap {
   position: relative;
-  min-width: 22rem;
-  // height: 10rem;
   border: 2px solid black;
   border-radius: 2px;
   background: #FFFFFF;
@@ -129,4 +127,8 @@ button {
 }
 .missing-ingredient{
   color: $red-hb;
+}
+
+.index h1 {
+  margin-left: 0;
 }

--- a/app/assets/stylesheets/components/_instructions.scss
+++ b/app/assets/stylesheets/components/_instructions.scss
@@ -1,24 +1,39 @@
 .instructions {
   margin-top: 5rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  column-gap: 5rem;
+  justify-items: center;
+}
+
+// Smaller devices (up to 767px)
+@media (max-width: 767px) {
+  .instructions {
+    grid-template-columns: 1fr;
+    row-gap: 5rem;
+  }
 }
 
 .instructions .step {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  flex: 1;
+  display: grid;
+  justify-items: center;
 }
 
 .instructions .step .step-header {
   color: $black-hb;
   font-weight: bolder;
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 20% 80%;
+  column-gap: 1rem;
   align-items: center;
-  flex: 1;
+  justify-items: center;
+}
+
+// Large devices (desktops, 992px and up)
+@media (min-width: 992px) {
+  .instructions .step .step-header {
+    column-gap: 0.5rem;
+  }
 }
 
 .instructions .step .step-header h3 {
@@ -28,22 +43,19 @@
 
 .instructions .step .step-header .step-number-circle {
   border-radius: 50%;
+  line-height: 40px;
   width: 48px;
   height: 48px;
   text-align: center;
   background-color: $red-instructions-hb;
   border: 2px solid $black-hb;
   color: white;
-  margin-right: 1rem;
 }
-
 
 .step-details {
   text-align: center;
-  padding: 3rem;
-  margin-left: 14px;
+  padding-top: 3rem;
 }
-
 
 .img_size {
   width: 160px;
@@ -51,61 +63,7 @@
   margin-bottom: -3rem;
 }
 
-
 .text-red-strong {
   color:$red-instructions-hb;
   font-weight: bolder;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-// .instructions{
-//   padding: 1rem;
-//   display: inline-flex;
-//   flex-direction: row;
-//   align-items: center;
-//   justify-content: center;
-
-//   display: flex;
-//   justify-content: space-around;
-//   flex-wrap: wrap;
-// }
-// .info{
-//   width: auto;
-//   max-width: 650px;
-//   margin-right: 2rem;
-// }
-// .img-instructions{
-//   // transform: rotate(-2deg);
-//   width: 160px;
-//   height: 200px;
-//   // border: 3px black solid;
-//   margin: 0 1rem;
-// }
-// .img-instructions2{
-//   // transform: rotate(2deg);
-//   width: 160px;
-//   height: 200px;
-//   // border: 3px black solid;
-//   margin: 0 1rem;
-// }
-// .images{
-//   display: flex;
-//   justify-content: space-around;
-//   flex-wrap: wrap;
-
-// }
-// .img_size{
-//   width: 160px;
-
-// }

--- a/app/assets/stylesheets/components/_saved_cocktail_card.scss
+++ b/app/assets/stylesheets/components/_saved_cocktail_card.scss
@@ -1,6 +1,5 @@
 .saved-cocktail-card-wrap {
   position: relative;
-  
   border: 2px solid $orange-hb;
   border-radius: 2px;
   background: #FFFFFF;
@@ -11,10 +10,52 @@
   }
 }
 
-.saved-cocktail-header {
-  display: grid;
-  grid-template-columns: 6.6rem 15.4rem 8rem;
-  align-items: center;
+// Small devices (up to 767px)
+@media (max-width: 767px) {
+  .saved-cocktail-card-wrap {
+    min-height: 11rem;
+    text-align: center;
+  }
+
+  .saved-cocktail-name {
+    font-family: $headers-font;
+    font-weight: 100;
+    text-align: center;
+    align-items: center;
+    justify-content: center;
+    flex-grow: 2;
+    min-height: 4rem;
+    display: flex;
+  }
+
+  .saved-cocktail-icon {
+    position: static;
+  }
+}
+
+// Medium devices (tablets, 768px and up)
+@media (min-width: 768px) {
+  .saved-cocktail-header {
+    display: grid;
+    grid-template-columns: 25% 50% 25%;
+    align-items: center;
+  }
+
+  .saved-cocktail-name {
+    font-family: $headers-font;
+    font-weight: 100;
+    align-items: center;
+    flex-grow: 2;
+    height: 4rem;
+    display: flex;
+    padding-left: 30px;
+  }
+
+  .fa-circle-plus, .fa-circle-minus {
+    position: absolute;
+    bottom: 2rem;
+    right: 0.5rem;
+  }
 }
 
 .saved-cocktail-stock {
@@ -32,22 +73,6 @@
     margin: 0;
     padding: 6px;
   }
-}
-
-.saved-cocktail-name {
-  font-family: $headers-font;
-  font-weight: 100;
-  align-items: center;
-  flex-grow: 2;
-  height: 4rem;
-  display: flex;
-  padding-left: 30px;
-}
-
-.fa-circle-plus, .fa-circle-minus {
-  position: absolute;
-  bottom: 1.8rem;
-  right: 0.5rem;
 }
 
 .fa-circle-minus {

--- a/app/assets/stylesheets/components/_saved_cocktail_card.scss
+++ b/app/assets/stylesheets/components/_saved_cocktail_card.scss
@@ -1,6 +1,6 @@
 .saved-cocktail-card-wrap {
   position: relative;
-  width: 30rem;
+  // width: 30rem;
   // height: 10rem;
   border: 2px solid $orange-hb;
   border-radius: 2px;
@@ -16,8 +16,6 @@
   display: grid;
   grid-template-columns: 6.6rem 15.4rem 8rem;
   align-items: center;
-  justify-content: center;
-  // border-bottom: 2px solid $orange-hb;
 }
 
 .saved-cocktail-stock {

--- a/app/assets/stylesheets/components/_saved_cocktail_card.scss
+++ b/app/assets/stylesheets/components/_saved_cocktail_card.scss
@@ -1,7 +1,6 @@
 .saved-cocktail-card-wrap {
   position: relative;
-  // width: 30rem;
-  // height: 10rem;
+  
   border: 2px solid $orange-hb;
   border-radius: 2px;
   background: #FFFFFF;

--- a/app/assets/stylesheets/components/_searchform.scss
+++ b/app/assets/stylesheets/components/_searchform.scss
@@ -15,6 +15,18 @@
   border: 1px solid #E7E7E7;
 }
 
+// Small devices (up to 767px)
+@media (max-width: 767px) {
+  .search-form-control .form-control{
+    margin-bottom: 1.5rem;
+    display: inline;
+    width: 90%;
+  }
+  .search-form-control .btn-flat {
+    right: 1.6rem;
+  }
+}
+
 .search-form-control .form-control:focus {
   border: 1px solid $orange-hb;
   outline: none !important;

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -16,7 +16,7 @@
 
 .index-card-wrap {
   position: relative;
-  width: 24rem;
+  // width: 24rem;
 }
 
 

--- a/app/views/components/_cabinet.html.erb
+++ b/app/views/components/_cabinet.html.erb
@@ -46,7 +46,7 @@
       <% user_ingredients.each do |item| %>
         <div class="btn-ghost ingredient d-flex align-items-center">
           <%= item.ingredient.name.titleize %>
-          <%= button_to raw("<i class=\"fa-regular fa-square-xmark\"></i>"),
+          <%= button_to raw("<i class=\"fa-solid fa-square-minus fa-lg\"></i>"),
             change_path(item.id),
             method: :patch,
             class: "remover" %>

--- a/app/views/components/_instructions.html.erb
+++ b/app/views/components/_instructions.html.erb
@@ -14,7 +14,7 @@
       <h3>Find Cocktails</h3>
     </div>
     <%= image_tag 'HomeBar_2.png',class:"img_size" %>
-    <p class="step-details">Discover which recipes fit your supplies <br> and <span class="text-red-strong">select favorites</span></p>
+    <p class="step-details">Discover which recipes fit your supplies and <span class="text-red-strong">select favorites</span></p>
   </div>
   <div class="step">
     <div class="step-header">

--- a/app/views/components/_saved_cocktail_card.html.erb
+++ b/app/views/components/_saved_cocktail_card.html.erb
@@ -25,7 +25,9 @@
       <div class="saved-cocktail-name">
         <h4><%= item.cocktail.name.titleize %></h4>
       </div>
-          <%= button_to "", saved_cocktail_path(item), method: :delete, class:"fa-solid fa-circle-minus fa-2xl" %>
+      <div>
+        <%= button_to "", saved_cocktail_path(item), method: :delete, class:"fa-solid fa-circle-minus fa-2xl saved-cocktail-icon" %>
+      </div>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
It's not perfect yet but I worked in the responsiveness of the website (remember the cocktail cards sticking out of the container at 100% zoom, the selected cocktails cards doing the same when we used smaller screens, the cabinet having a similar issue, the numbers of the instructions becoming ellipses in small screens...) so that at least we can show in the mobile phone and looks OKish ;). Main changes:

- Homepage: now the instructions are responsive. Arranged in a row for larger screens and in a column for smaller screens... and no strange ellipses instead of circles for the numbers. I mainly used grid layouts (instead of flex) for fixing this issue.

![localhost_3000_(Nest Hub Max) (1)](https://user-images.githubusercontent.com/99300646/194564055-f240b24d-a4f5-43e8-b780-304b665e45b9.png)

![localhost_3000_(iPad Mini)](https://user-images.githubusercontent.com/99300646/194564266-796f2e3d-5bf8-4d97-94cf-dfb50b155453.png)

![localhost_3000_(iPhone 12 Pro)](https://user-images.githubusercontent.com/99300646/194564287-1148627e-897f-40af-a791-d530f39452e5.png)
<br>
<br>
- Cocktails index page: cocktail cards do not stick out of the container adapting to the size of the screen... a bit larger, a bit smaller or arranged in a column instead of a grid  (this last step I think was already coded by one of you guys). The cabinet is also responsive: for smaller screens the elements are arranged in a column instead of the default layout... the search bar adapts also to that.

![localhost_3000_cocktails(Nest Hub Max)](https://user-images.githubusercontent.com/99300646/194565904-b603142c-ea47-418e-a6f7-25d9259774b1.png)

![localhost_3000_cocktails(iPad Mini)](https://user-images.githubusercontent.com/99300646/194565918-5468ecf8-8659-46d8-a84f-e70299614cd4.png)

![localhost_3000_cocktails(iPhone 12 Pro)](https://user-images.githubusercontent.com/99300646/194565957-2847b9b6-0899-407f-99bf-2bf6a0f52179.png)
<br>
<br>
- Saved cocktails and grocery list index page: the cabinet is responsive as I explained before and the cocktails cards and the grocery list too. The selected cocktails cards change the layout when we use a smaller screen to fit the content.

![localhost_3000_saved_cocktails(Nest Hub Max)](https://user-images.githubusercontent.com/99300646/194567354-4be13055-7f80-470f-b0ae-da742a2b82bb.png)
![localhost_3000_saved_cocktails(iPad Mini)](https://user-images.githubusercontent.com/99300646/194567365-da3e43ef-0daa-4ead-aa50-2c149b62c065.png)
![localhost_3000_saved_cocktails(iPhone 12 Pro)](https://user-images.githubusercontent.com/99300646/194567376-8f7fda04-0840-444d-8a0c-ec4d0dd1ded1.png)
<br>
<br>
Check it and if you think it's ok, merge it. I think at least it's much more responsive now... 